### PR TITLE
Add tcp support

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id 'java-library'
 	id 'maven-publish'
-	id 'org.springframework.boot' version '2.5.6' apply false
+	id 'org.springframework.boot' version '2.6.0' apply false
 	id 'io.spring.dependency-management' version '1.0.11.RELEASE'
 	// Kotlin Language
 	id "org.jetbrains.kotlin.jvm" version '1.5.31'
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = 'me.yaman.can'
-version = '0.0.1'
+version = '0.0.2'
 sourceCompatibility = '11'
 
 repositories {

--- a/lib/src/main/resources/META-INF/spring-configuration-metadata.json
+++ b/lib/src/main/resources/META-INF/spring-configuration-metadata.json
@@ -26,6 +26,19 @@
       "sourceType": "me.yaman.can.webflux.h2console.H2ConsoleAutoconfiguration.Properties",
       "description": "h2-console server run port, default is random port",
       "defaultValue": 0
+    },
+    {
+      "name": "spring.h2.console.tcp-enabled",
+      "type": "java.lang.Boolean",
+      "sourceType": "me.yaman.can.webflux.h2console.H2ConsoleAutoconfiguration.Properties",
+      "description": "activate h2-console tcp support"
+    },
+    {
+      "name": "spring.h2.console.tcp-port",
+      "type": "java.lang.Integer",
+      "sourceType": "me.yaman.can.webflux.h2console.H2ConsoleAutoconfiguration.Properties",
+      "description": "h2-console tcp server run port, default is random port",
+      "defaultValue": 0
     }
   ],
   "hints": [
@@ -64,6 +77,32 @@
         },
         {
           "value": "8082",
+          "description": "Default h2-console web server port"
+        }
+      ]
+    },
+    {
+      "name": "h2.console.tcp-enabled",
+      "values": [
+        {
+          "value": "true",
+          "description": "Enable h2-console tcp service."
+        },
+        {
+          "value": "false",
+          "description": "Disable h2-console tcp service."
+        }
+      ]
+    },
+    {
+      "name": "h2.console.tcp-port",
+      "values": [
+        {
+          "value": "0",
+          "description": "This is random, available port. Recommended value."
+        },
+        {
+          "value": "9092",
           "description": "Default h2-console web server port"
         }
       ]


### PR DESCRIPTION
Right now it's not possible to connect to in memory db from any db client except web interface (I was trying from Intellij db client).
The easiest way to achieve that is to start TCP server along with web server, as it described here:
https://stackoverflow.com/a/52949164/4937841

With this enhancement I was able to connect to inmemory db through tcp.